### PR TITLE
Fix release tag/title format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add VERSION
           git commit -m "Bump version to ${{ steps.version.outputs.version }}"
-          git tag "v${{ steps.version.outputs.version }}"
+          git tag "release/v${{ steps.version.outputs.version }}"
           git push origin main --tags
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: "v${{ steps.version.outputs.version }}"
-          name: "v${{ steps.version.outputs.version }}"
+          tag_name: "release/v${{ steps.version.outputs.version }}"
+          name: "Release Version ${{ steps.version.outputs.version }}"
           generate_release_notes: true

--- a/server.py
+++ b/server.py
@@ -3440,12 +3440,12 @@ input[type="checkbox"] {{ margin-right: 6px; }}
                 cwd=str(ROOT), capture_output=True, text=True, timeout=30
             )
             result = subprocess.run(
-                ["git", "tag", "-l", "v*", "--sort=-version:refname"],
+                ["git", "tag", "-l", "release/v*", "--sort=-version:refname"],
                 cwd=str(ROOT), capture_output=True, text=True, timeout=10
             )
             if result.returncode == 0 and result.stdout.strip():
                 latest_tag = result.stdout.strip().split("\n")[0]
-                latest = latest_tag.lstrip("v")
+                latest = latest_tag.replace("release/v", "")
                 if latest != current:
                     update_available = True
         except Exception as e:


### PR DESCRIPTION
## Summary
- 릴리즈 태그 형식 변경: `v1.1.0` → `release/v1.1.0`
- 릴리즈 타이틀 형식 변경: `v1.1.0` → `Release Version 1.1.0`
- server.py 태그 파싱 로직을 새 형식에 맞게 수정

## Test plan
- [ ] 기존 릴리즈 태그/타이틀이 새 형식으로 변경되었는지 확인
- [ ] DEV > 일반 > 업데이트 확인 시 `release/v*` 태그 정상 파싱 확인
- [ ] 다음 PR 머지 시 새 형식으로 릴리즈 자동 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)