### PR TITLE
Fix 메인 도구 항목이 플러그인 섹션에 중복 표시되는 버그

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -120,7 +120,7 @@ function applyTabConfig() {
       }
     });
     // DOM 순서 재정렬 — DEV 버튼과 구분선 앞에 삽입
-    var $divider = $nav.find(".nav-divider");
+    var $divider = $nav.find(".nav-divider").first();
     tabs.forEach(function (tab) {
       var $btn = $nav.find(".nav-btn[data-tab='" + tab.id + "']");
       if ($btn.length && $divider.length) $divider.before($btn);


### PR DESCRIPTION
## Summary
- `applyTabConfig()`에서 `.nav-divider` 선택 시 `.first()`를 누락하여, 플러그인 로더가 추가한 custom-divider까지 매칭되면서 jQuery `.before()`가 메인 도구 버튼을 복제하는 문제 수정

## 원인
- `plugin-loader.js`가 사이드바에 `.nav-divider.custom-divider`를 추가 → divider가 2개
- `applyTabConfig()`의 `$nav.find(".nav-divider")`가 2개 모두 매칭
- jQuery `.before()`가 multi-element set에 대해 clone + 이동을 수행하여 버튼이 플러그인 영역에도 표시

## 수정
- `$nav.find(".nav-divider")` → `$nav.find(".nav-divider").first()`

## Test plan
- [ ] 서버 첫 실행 후 사이드바에서 메인 도구가 플러그인 섹션에 중복되지 않는지 확인
- [ ] 새로고침 후에도 정상 동작 확인
- [ ] 플러그인이 없는 경우에도 정상 동작 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)