### PR TITLE
[Feature] AI 프로바이더 기본 모델 최신화 및 Grok SDK 업데이트

### DIFF
--- a/server.py
+++ b/server.py
@@ -153,10 +153,10 @@ except ImportError:
 
 # ── AI Provider abstraction ──
 AI_PROVIDERS = {
-    "openai":  {"label": "OpenAI",  "default_model": "gpt-4.1-nano"},
-    "gemini":  {"label": "Gemini",  "default_model": "gemini-2.0-flash-lite"},
+    "openai":  {"label": "OpenAI",  "default_model": "gpt-5-nano"},
+    "gemini":  {"label": "Gemini",  "default_model": "gemini-3.1-flash-lite-preview"},
     "claude":  {"label": "Claude",  "default_model": "claude-haiku-4-5-20251001"},
-    "grok":    {"label": "Grok",    "default_model": "grok-3-mini-fast"},
+    "grok":    {"label": "Grok",    "default_model": "grok-4.1-fast"},
 }
 
 
@@ -247,11 +247,15 @@ def _ai_chat(provider, system_prompt, user_prompt, model=None):
     elif provider == "grok":
         if xai_sdk is None:
             raise RuntimeError("xai-sdk package not installed")
+        from xai_sdk.chat import system as _xai_system, user as _xai_user
         client = xai_sdk.Client(api_key=api_key)
-        conversation = client.chat.create(model=model)
-        conversation.add_system(system_prompt)
-        resp = conversation.add_user(user_prompt)
-        return resp.text.strip()
+        chat = client.chat.create(
+            model=model,
+            messages=[_xai_system(system_prompt)],
+        )
+        chat.append(_xai_user(user_prompt))
+        resp = chat.sample()
+        return (resp.content or "").strip()
 
     else:
         raise ValueError(f"Unsupported provider: {provider}")


### PR DESCRIPTION
## Summary

- OpenAI `gpt-4.1-nano` → `gpt-5-nano` ($0.05/$0.40 per 1M tokens)
- Gemini `gemini-2.0-flash-lite` → `gemini-3.1-flash-lite-preview` ($0.25/$1.50 per 1M tokens)
- Grok `grok-3-mini-fast` → `grok-4.1-fast` ($0.20/$0.50 per 1M tokens)
- Claude `claude-haiku-4-5-20251001` 유지 (이미 최신 + 최저가)

### xai_sdk Breaking Change 대응

xai-sdk API 방식이 변경되어 `_ai_chat()` Grok 구현부 수정:

| | 구 (grok-3-mini-fast) | 신 (grok-4.1-fast) |
|---|---|---|
| 시스템 메시지 | `conversation.add_system(prompt)` | `messages=[system(prompt)]` |
| 유저 메시지 | `conversation.add_user(prompt)` | `chat.append(user(prompt))` |
| 응답 획득 | 반환값 직접 사용 | `chat.sample()` |
| 응답 텍스트 | `resp.text` | `resp.content` |

## Test plan

- [ ] OpenAI `gpt-5-nano` 기본 호출 정상 동작 확인
- [ ] Gemini `gemini-3.1-flash-lite-preview` 기본 호출 정상 동작 확인
- [ ] Grok `grok-4.1-fast` 기본 호출 정상 동작 확인 (새 SDK API)
- [ ] 번역, DataAI, 맞춤법 기능에서 4개 provider 각각 테스트
- [ ] AI 리서치 플러그인 웹 검색 기반 리서치 동작 확인

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)